### PR TITLE
Fix permissions for SSH key in deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,9 +24,10 @@ jobs:
         run: |
           mkdir -p ~/.ssh
           echo "$SSH_KEY" > ~/.ssh/id_rsa
+          chmod 700 ~/.ssh
           chmod 600 ~/.ssh/id_rsa
           ssh-keyscan merah.cassia.ifost.org.au >> ~/.ssh/known_hosts
 
       - name: Deploy HTML files
         run: |
-          scp *.html merah.cassia.ifost.org.au:/var/www/vhosts/learning-theory.arithmetic.guru/htdocs/
+          scp -i ~/.ssh/id_rsa *.html merah.cassia.ifost.org.au:/var/www/vhosts/learning-theory.arithmetic.guru/htdocs/


### PR DESCRIPTION
## Summary
- update SSH setup step to set secure directory and key permissions
- explicitly use the key when uploading the HTML files

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68424e7397188325807f1381b924da4b