### PR TITLE
Fix SSH key path for deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,11 +23,12 @@ jobs:
           SSH_KEY: ${{ env.NUMBER_TARGET_SSH_KEY }}
         run: |
           mkdir -p ~/.ssh
-          echo "$SSH_KEY" > ~/.ssh/id_rsa
+          echo "$SSH_KEY" > ~/.ssh/id_ed25519
           chmod 700 ~/.ssh
-          chmod 600 ~/.ssh/id_rsa
+          chmod 600 ~/.ssh/id_ed25519
           ssh-keyscan merah.cassia.ifost.org.au >> ~/.ssh/known_hosts
+          head -n 1 ~/.ssh/id_ed25519
 
       - name: Deploy HTML files
         run: |
-          scp -i ~/.ssh/id_rsa *.html merah.cassia.ifost.org.au:/var/www/vhosts/learning-theory.arithmetic.guru/htdocs/
+          scp -i ~/.ssh/id_ed25519 *.html merah.cassia.ifost.org.au:/var/www/vhosts/learning-theory.arithmetic.guru/htdocs/


### PR DESCRIPTION
## Summary
- write deployment key to `id_ed25519`
- print first line of key to verify correct value
- use updated key for `scp`

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest` *(0 tests ran)*
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_6843aa916670832591a6c8bf0ce9d70d